### PR TITLE
Fix: align.py doctest error

### DIFF
--- a/package/MDAnalysis/analysis/align.py
+++ b/package/MDAnalysis/analysis/align.py
@@ -80,14 +80,14 @@ two structures, using :func:`rmsd`::
 
 Note that in this example translations have not been removed. In order
 to look at the pure rotation one needs to superimpose the centres of
-mass (or geometry) first:
+mass (or geometry) first::
 
    >>> rmsd(mobile.select_atoms('name CA').positions, ref.select_atoms('name CA').positions, center=True)
    21.892591663632704
 
 This has only done a translational superposition. If you want to also do a
 rotational superposition use the superposition keyword. This will calculate a
-minimized RMSD between the reference and mobile structure.
+minimized RMSD between the reference and mobile structure::
 
    >>> rmsd(mobile.select_atoms('name CA').positions, ref.select_atoms('name CA').positions, 
    ...      superposition=True)


### PR DESCRIPTION
Partially address https://github.com/MDAnalysis/mdanalysis/issues/3925

Changes made in this Pull Request:

- Doctest for **align.py**
(`package/MDAnalysis/analysis/encore/dimensionality_reduction/align.py`) file contains these errors:

- NameError: name `rmsd` is not defined: reason were typo errors, which required to add `::` in the end of two sentences to fix

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
