### PR TITLE
Talagayev patch 1 singleframe

### DIFF
--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -25,6 +25,7 @@ import pickle
 
 import numpy as np
 import pytest
+from pathlib import Path
 from unittest import TestCase
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_allclose)
@@ -125,6 +126,12 @@ class _SingleFrameReader(TestCase, RefAdKSmall):
         assert_equal(len(reader), len(reader_p))
         assert_equal(reader.ts, reader_p.ts,
                      "Single-frame timestep is changed after pickling")
+
+    def test_pathlib_input_single(self):
+        path = Path(self.filename)
+        u_str = mda.Universe(self.filename)
+        u_path = mda.Universe(path)
+        assert u_str.atoms.n_atoms == u_path.atoms.n_atoms
 
 
 class BaseReference(object):

--- a/testsuite/MDAnalysisTests/coordinates/base.py
+++ b/testsuite/MDAnalysisTests/coordinates/base.py
@@ -32,6 +32,7 @@ from numpy.testing import (assert_equal, assert_almost_equal,
 
 import MDAnalysis as mda
 from MDAnalysis.coordinates.timestep import Timestep
+from MDAnalysis.coordinates.memory import MemoryReader
 from MDAnalysis.transformations import translate
 
 
@@ -528,6 +529,19 @@ class BaseReaderTest(object):
         atoms = mda.Universe(reader.filename).select_atoms("index 1")
         with pytest.raises(ValueError, match="Cannot provide both"):
             timeseries = reader.timeseries(atomgroup=atoms, asel=atoms, order='fac')
+          
+    def test_pathlib_input_base(self, reader):     
+        skip_formats = ["DCD", "TNG", "XTC", "TRR"]
+        if isinstance(reader, MemoryReader) or reader.format in skip_formats:
+            if isinstance(reader, MemoryReader):
+                skip_reason = "MemoryReader"
+            else:
+                skip_reason = f"{reader.format} file format"
+            pytest.skip(f"Skipping test for {skip_reason}")
+        path = Path(reader.filename)
+        u_str = mda.Universe(reader.filename)
+        u_path = mda.Universe(path)
+        assert u_str.atoms.n_atoms == u_path.atoms.n_atoms
 
 
 class MultiframeReaderTest(BaseReaderTest):

--- a/testsuite/MDAnalysisTests/coordinates/test_gro.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_gro.py
@@ -21,7 +21,6 @@
 # J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
 #
 from io import StringIO
-from pathlib import Path
 
 import MDAnalysis as mda
 import numpy as np
@@ -529,16 +528,3 @@ def test_gro_empty_box_write_read(tmpdir):
         with pytest.warns(UserWarning, match=wmsg):
             u2 = mda.Universe('test.gro')
         assert u2.dimensions is None
-
-
-def test_gro_pathlib_singleframereaderbase():
-    top = Path(GRO)
-    assert isinstance(top, Path)
-    u = mda.Universe(top)
-    assert u.atoms.n_atoms == 47681
-
-
-def test_gro_string_singleframereaderbase():
-    assert isinstance(GRO, str)
-    u = mda.Universe(GRO)
-    assert u.atoms.n_atoms == 47681

--- a/testsuite/MDAnalysisTests/coordinates/test_lammps.py
+++ b/testsuite/MDAnalysisTests/coordinates/test_lammps.py
@@ -30,7 +30,6 @@ import MDAnalysis as mda
 from MDAnalysis import NoDataError
 
 from numpy.testing import (assert_equal, assert_allclose)
-from pathlib import Path
 
 from MDAnalysisTests import make_Universe
 from MDAnalysisTests.coordinates.reference import (
@@ -820,16 +819,3 @@ class TestLammpsTriclinic(object):
                             rtol=1e-5, atol=0)
 
         assert_allclose(u_data.dimensions, reference_box, rtol=1e-5, atol=0)
-
-
-def test_pathlib_lammps_singleframereaderbase():
-    top = Path(LAMMPSdata)
-    assert isinstance(top, Path)
-    u = mda.Universe(top)
-    assert u.atoms.n_atoms == 18364
-
-
-def test_string_lammps_singleframereaderbase():
-    assert isinstance(LAMMPSdata, str)
-    u = mda.Universe(LAMMPSdata)
-    assert u.atoms.n_atoms == 18364


### PR DESCRIPTION
Partially Fixes #3937 . The issue mentioned the addition of support and testing for `pathlib` objects for `SingleFrameReaderBase`.

Currently the `SingleFrameReaderBase` is able to handle both `pathlib` and `str` as input for `SingleFrameReaderBase` to display this, this PR is focusing on tests that display the handling of `pathlib` and `str` as input for `SingleFrameReaderBase` .

Changes made in this Pull Request:
 - Adjusted the tests in `base` for `SingleFrameReaderBase` to work for current formats with exceptions added for non single frame formats.


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the LGPLv2.1+ license as defined in our [LICENSE](https://github.com/MDAnalysis/mdanalysis/blob/develop/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
